### PR TITLE
feat: OGP/Twitter Cardメタデータサポートを追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://nw-union.net",
   outDir: "./build",
   adapter: cloudflare({
     platformProxy: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,13 @@ const metaOgType = ogType || "website";
 const metaOgUrl = ogUrl || Astro.url.href;
 const metaOgTitle = ogTitle || title;
 const metaOgDescription = ogDescription || description;
-const metaOgImage = ogImage || "/img/icon_196.png";
+
+// OGP画像URLを絶対URLに変換
+const ogImagePath = ogImage || "/img/icon_196.png";
+const metaOgImage = ogImagePath.startsWith('http') 
+  ? ogImagePath 
+  : new URL(ogImagePath, Astro.url.origin).href;
+
 const metaTwitterCard = twitterCard || "summary";
 ---
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,10 +28,11 @@ const metaOgTitle = ogTitle || title;
 const metaOgDescription = ogDescription || description;
 
 // OGP画像URLを絶対URLに変換
+const siteUrl = Astro.site?.href || "https://nw-union.net";
 const ogImagePath = ogImage || "/img/icon_196.png";
 const metaOgImage = ogImagePath.startsWith("http")
   ? ogImagePath
-  : new URL(ogImagePath, Astro.url.origin).href;
+  : new URL(ogImagePath, siteUrl).href;
 
 const metaTwitterCard = twitterCard || "summary";
 ---

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,9 +2,32 @@
 export interface Props {
   title: string;
   description: string;
+  ogType?: string;
+  ogUrl?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImage?: string;
+  twitterCard?: string;
 }
 
-const { title, description } = Astro.props;
+const {
+  title,
+  description,
+  ogType,
+  ogUrl,
+  ogTitle,
+  ogDescription,
+  ogImage,
+  twitterCard,
+} = Astro.props;
+
+// OGPメタデータのデフォルト値を設定
+const metaOgType = ogType || "website";
+const metaOgUrl = ogUrl || Astro.url.href;
+const metaOgTitle = ogTitle || title;
+const metaOgDescription = ogDescription || description;
+const metaOgImage = ogImage || "/img/icon_196.png";
+const metaTwitterCard = twitterCard || "summary";
 ---
 
 <!DOCTYPE html>
@@ -17,20 +40,21 @@ const { title, description } = Astro.props;
     <meta name="description" content={description} />
 
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={Astro.url} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content="/img/icon_512.png" />
-    <meta property="og:image:width" content="512" />
-    <meta property="og:image:height" content="512" />
+    <meta property="og:type" content={metaOgType} />
+    <meta property="og:url" content={metaOgUrl} />
+    <meta property="og:title" content={metaOgTitle} />
+    <meta property="og:description" content={metaOgDescription} />
+    <meta property="og:image" content={metaOgImage} />
+    <meta property="og:site_name" content="NWU" />
+    <meta property="og:locale" content="ja_JP" />
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary" />
-    <meta property="twitter:url" content={Astro.url} />
-    <meta property="twitter:title" content={title} />
-    <meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content="/img/icon_512.png" />
+    <meta property="twitter:card" content={metaTwitterCard} />
+    <meta property="twitter:url" content={metaOgUrl} />
+    <meta property="twitter:title" content={metaOgTitle} />
+    <meta property="twitter:description" content={metaOgDescription} />
+    <meta property="twitter:image" content={metaOgImage} />
+
     <link
       rel="apple-touch-icon"
       sizes="192x192"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,11 +56,11 @@ const metaTwitterCard = twitterCard || "summary";
     <meta property="og:locale" content="ja_JP" />
 
     <!-- Twitter -->
-    <meta property="twitter:card" content={metaTwitterCard} />
-    <meta property="twitter:url" content={metaOgUrl} />
-    <meta property="twitter:title" content={metaOgTitle} />
-    <meta property="twitter:description" content={metaOgDescription} />
-    <meta property="twitter:image" content={metaOgImage} />
+    <meta name="twitter:card" content={metaTwitterCard} />
+    <meta name="twitter:url" content={metaOgUrl} />
+    <meta name="twitter:title" content={metaOgTitle} />
+    <meta name="twitter:description" content={metaOgDescription} />
+    <meta name="twitter:image" content={metaOgImage} />
 
     <link
       rel="apple-touch-icon"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -29,8 +29,8 @@ const metaOgDescription = ogDescription || description;
 
 // OGP画像URLを絶対URLに変換
 const ogImagePath = ogImage || "/img/icon_196.png";
-const metaOgImage = ogImagePath.startsWith('http') 
-  ? ogImagePath 
+const metaOgImage = ogImagePath.startsWith("http")
+  ? ogImagePath
   : new URL(ogImagePath, Astro.url.origin).href;
 
 const metaTwitterCard = twitterCard || "summary";

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -2,6 +2,14 @@
 import "../styles/markdown.css";
 
 const { frontmatter } = Astro.props;
+
+// OGPメタデータのデフォルト値を設定
+const ogType = frontmatter.ogType || "website";
+const ogUrl = frontmatter.ogUrl || Astro.url.href;
+const ogTitle = frontmatter.ogTitle || frontmatter.title;
+const ogDescription = frontmatter.ogDescription || frontmatter.description;
+const ogImage = frontmatter.ogImage || "/img/icon_196.png";
+const twitterCard = frontmatter.twitterCard || "summary";
 ---
 
 <!DOCTYPE html>
@@ -12,6 +20,23 @@ const { frontmatter } = Astro.props;
 
     <title>{frontmatter.title}</title>
     <meta name="description" content={frontmatter.description} />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={ogUrl} />
+    <meta property="og:title" content={ogTitle} />
+    <meta property="og:description" content={ogDescription} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:site_name" content="NWU" />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content={twitterCard} />
+    <meta property="twitter:url" content={Astro.url} />
+    <meta property="twitter:title" content={ogTitle} />
+    <meta property="twitter:description" content={ogDescription} />
+    <meta property="twitter:image" content={ogImage} />
+
     <link
       rel="apple-touch-icon"
       sizes="192x192"

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -10,10 +10,11 @@ const ogTitle = frontmatter.ogTitle || frontmatter.title;
 const ogDescription = frontmatter.ogDescription || frontmatter.description;
 
 // OGP画像URLを絶対URLに変換
+const siteUrl = Astro.site?.href || "https://nw-union.net";
 const ogImagePath = frontmatter.ogImage || "/img/icon_196.png";
 const ogImage = ogImagePath.startsWith("http")
   ? ogImagePath
-  : new URL(ogImagePath, Astro.url.origin).href;
+  : new URL(ogImagePath, siteUrl).href;
 
 const twitterCard = frontmatter.twitterCard || "summary";
 ---

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -11,7 +11,7 @@ const ogDescription = frontmatter.ogDescription || frontmatter.description;
 
 // OGP画像URLを絶対URLに変換
 const ogImagePath = frontmatter.ogImage || "/img/icon_196.png";
-const ogImage = ogImagePath.startsWith('http')
+const ogImage = ogImagePath.startsWith("http")
   ? ogImagePath
   : new URL(ogImagePath, Astro.url.origin).href;
 

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -38,11 +38,11 @@ const twitterCard = frontmatter.twitterCard || "summary";
     <meta property="og:locale" content="ja_JP" />
 
     <!-- Twitter -->
-    <meta property="twitter:card" content={twitterCard} />
-    <meta property="twitter:url" content={Astro.url} />
-    <meta property="twitter:title" content={ogTitle} />
-    <meta property="twitter:description" content={ogDescription} />
-    <meta property="twitter:image" content={ogImage} />
+    <meta name="twitter:card" content={twitterCard} />
+    <meta name="twitter:url" content={ogUrl} />
+    <meta name="twitter:title" content={ogTitle} />
+    <meta name="twitter:description" content={ogDescription} />
+    <meta name="twitter:image" content={ogImage} />
 
     <link
       rel="apple-touch-icon"

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -8,7 +8,13 @@ const ogType = frontmatter.ogType || "website";
 const ogUrl = frontmatter.ogUrl || Astro.url.href;
 const ogTitle = frontmatter.ogTitle || frontmatter.title;
 const ogDescription = frontmatter.ogDescription || frontmatter.description;
-const ogImage = frontmatter.ogImage || "/img/icon_196.png";
+
+// OGP画像URLを絶対URLに変換
+const ogImagePath = frontmatter.ogImage || "/img/icon_196.png";
+const ogImage = ogImagePath.startsWith('http')
+  ? ogImagePath
+  : new URL(ogImagePath, Astro.url.origin).href;
+
 const twitterCard = frontmatter.twitterCard || "summary";
 ---
 

--- a/src/pages/docs/demo.md
+++ b/src/pages/docs/demo.md
@@ -1,6 +1,9 @@
 ---
 layout: "../../layouts/Markdown.astro"
 title: "マークダウンデモページ | NWU"
+description: "Astroで作成されたサイトのマークダウンレンダリングのデモページです"
+ogTitle: "マークダウンデモページ | NW UNION"
+ogDescription: "マークダウンの各種要素の表示を確認できるデモページです"
 ---
 
 # マークダウン デモページ

--- a/src/pages/docs/nwu_summer.md
+++ b/src/pages/docs/nwu_summer.md
@@ -1,6 +1,9 @@
 ---
 layout: "../../layouts/Markdown.astro"
 title: "NWU SUMMER"
+description: "夏だから面白いことしようぜ！"
+ogImage: "/img/docs/nwu_summer.png"
+twitterCard: "summary_large_image"
 ---
 
 # NWU SUMMER


### PR DESCRIPTION
## 概要
このPRでは、AstroサイトにOGP（Open Graph Protocol）およびTwitter Cardメタデータのサポートを追加しました。これにより、SNSでシェアした際のプレビュー表示を改善できます。

## 変更内容
- `Layout.astro`に柔軟なOGP/Twitter Cardメタデータ設定機能を追加
- `Markdown.astro`にも同様の機能を追加（frontmatterから設定可能）
- 相対パスで指定されたOGP画像URLを自動的に絶対URLに変換する機能を実装
- デフォルト値の設定により、最小限の設定で動作するように配慮
- `og:site_name`と`og:locale`の追加でより適切なSNS表示を実現

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
### 使用例
```astro
---
// Layout.astroの使用例
<Layout 
  title="ページタイトル"
  description="ページの説明"
  ogImage="/img/custom-og-image.png"
  twitterCard="summary_large_image"
/>

// Markdown.astroの使用例（frontmatter）
---
layout: "../../layouts/Markdown.astro"
title: "NWU SUMMER"
description: "夏だから面白いことしようぜ！"
ogImage: "/img/docs/nwu_summer.png"
twitterCard: "summary_large_image"
---
```

### 実装のポイント
- OGP画像の相対パスを絶対URLに自動変換することで、開発者の負担を軽減
- デフォルト値を適切に設定し、最小限の設定で動作するように配慮
- Twitter Card用のメタデータも同時に設定し、各プラットフォームでの表示を最適化

--

GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと