### PR TITLE
ドキュメントページにパンクズリスト機能を追加

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,40 @@
+---
+interface Props {
+  currentTitle: string;
+}
+
+const { currentTitle } = Astro.props;
+const pathname = Astro.url.pathname;
+
+// パンクズリスト生成ロジック
+const breadcrumbs = [];
+
+if (pathname.startsWith('/docs')) {
+  breadcrumbs.push({ title: 'TOP', url: '/' });
+  breadcrumbs.push({ title: 'Docs', url: '/docs' });
+  
+  // 現在のページが /docs 自体でない場合は、現在のページタイトルを追加
+  if (pathname !== '/docs' && pathname !== '/docs/') {
+    // タイトルから " | NWU" を除去してクリーンなタイトルを取得
+    const cleanTitle = currentTitle?.replace(/\s*\|\s*NWU$/, '') || 'ページ';
+    breadcrumbs.push({ title: cleanTitle, url: null }); // 現在のページはリンクなし
+  }
+}
+---
+
+{breadcrumbs.length > 0 && (
+  <nav class="mb-8 text-sm text-gray-400" aria-label="パンクズリスト">
+    {breadcrumbs.map((crumb, index) => (
+      <span key={index}>
+        {crumb.url ? (
+          <a href={crumb.url} class="text-cyan-400 hover:text-cyan-300 hover:underline transition-colors">
+            {crumb.title}
+          </a>
+        ) : (
+          <span class="text-gray-300">{crumb.title}</span>
+        )}
+        {index < breadcrumbs.length - 1 && <span class="mx-2">＞</span>}
+      </span>
+    ))}
+  </nav>
+)}

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/markdown.css";
+import Breadcrumb from "../components/Breadcrumb.astro";
 
 const { frontmatter } = Astro.props;
 
@@ -54,6 +55,7 @@ const twitterCard = frontmatter.twitterCard || "summary";
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sawarabi+Gothic&family=VT323&display=swap" rel="stylesheet" />
   </head>
   <body class="bg-black font-sg leading-relaxed text-base md:w-700 w-full mx-auto p-6 text-gray-300">
+    <Breadcrumb currentTitle={frontmatter.title} />
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## 概要
`src/pages/docs/`配下のドキュメントページにパンクズリスト機能を実装しました。

TOP ＞ Docs ＞ 現在のページタイトル

の形式でナビゲーションを表示し、ユーザーのサイト内ナビゲーションを改善します。

## 変更内容
- [x] `src/components/Breadcrumb.astro`コンポーネントを新規作成
- [x] `src/layouts/Markdown.astro`レイアウトにパンクズリストを統合
- [x] ページタイトルから"| NWU"サフィックスの除去

## テスト
- [x] 手動でコードレビューを実施
- [ ] `bun run dev`でローカル環境での動作確認
- [ ] ドキュメントページの表示確認

## チェックリスト
- [x] コードレビューの準備ができている
- [x] 自分でコードをレビューした
- [x] 変更がプロジェクトのガイドラインに従っている

Generated with [Claude Code](https://claude.ai/code)