### PR TITLE
feat: ダークモード切り替え機能を追加

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,45 @@
+---
+---
+
+<button
+  id="theme-toggle"
+  class="fixed top-4 right-4 z-50 p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors duration-200 border border-gray-600"
+  aria-label="テーマを切り替える"
+>
+  <svg class="w-6 h-6 text-yellow-400 dark:hidden" fill="currentColor" viewBox="0 0 20 20">
+    <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd" />
+  </svg>
+  <svg class="w-6 h-6 text-gray-300 hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
+    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+  </svg>
+</button>
+
+<script>
+  const theme = (() => {
+    if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+      return localStorage.getItem('theme');
+    }
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  })();
+
+  if (theme === 'light') {
+    document.documentElement.classList.remove('dark');
+  } else {
+    document.documentElement.classList.add('dark');
+  }
+
+  window.localStorage.setItem('theme', theme);
+
+  const handleToggleClick = () => {
+    const element = document.documentElement;
+    element.classList.toggle('dark');
+    
+    const isDark = element.classList.contains('dark');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  };
+
+  document.getElementById('theme-toggle')?.addEventListener('click', handleToggleClick);
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -71,7 +71,7 @@ const metaTwitterCard = twitterCard || "summary";
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sawarabi+Gothic&family=VT323&display=swap" rel="stylesheet" />
   </head>
-  <body class="bg-black font-inter leading-relaxed text-base w-full mx-auto text-zinc-900">
+  <body class="bg-white dark:bg-black font-inter leading-relaxed text-base w-full mx-auto text-zinc-900 dark:text-zinc-100 transition-colors duration-300">
     <slot />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import ThemeToggle from "../components/ThemeToggle.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
@@ -6,38 +7,39 @@ import Layout from "../layouts/Layout.astro";
   title="NWU"
   description="We are Hangout crew. Lovers of Culture, Art and Tech!"
 >
-  <main class="bg-black min-h-screen flex flex-col justify-start items-center p-4 pt-8 md:pt-14">
-    <div class="bg-black font-vt323 text-2xl md:text-4xl leading-relaxed md:leading-loose max-w-4xl w-full">
-      <div class="p-3 md:p-5 bg-black min-h-300 md:min-h-400">
+  <ThemeToggle />
+  <main class="bg-white dark:bg-black min-h-screen flex flex-col justify-start items-center p-4 pt-8 md:pt-14 transition-colors duration-300">
+    <div class="bg-gray-100 dark:bg-black font-vt323 text-2xl md:text-4xl leading-relaxed md:leading-loose max-w-4xl w-full transition-colors duration-300 rounded-lg p-2">
+      <div class="p-3 md:p-5 bg-gray-100 dark:bg-black min-h-300 md:min-h-400 transition-colors duration-300 rounded">
         <div class="terminal-line flex items-center my-2 gap-2 opacity-0" id="line-1">
-          <span class="text-green-400 font-bold">$</span>
-          <span class="text-white" id="cmd-1"></span>
+          <span class="text-green-600 dark:text-green-400 font-bold">$</span>
+          <span class="text-gray-800 dark:text-white" id="cmd-1"></span>
         </div>
         <div class="terminal-output my-2 mb-4 pl-0 opacity-0" id="output-1">
-          <div class="typing-text text-green-400 opacity-0 whitespace-pre font-mono text-xs md:text-sm" id="name-text"></div>
-          <div class="typing-text text-green-400 opacity-0 mt-2" id="about-text"></div>
+          <div class="typing-text text-green-600 dark:text-green-400 opacity-0 whitespace-pre font-mono text-xs md:text-sm" id="name-text"></div>
+          <div class="typing-text text-green-600 dark:text-green-400 opacity-0 mt-2" id="about-text"></div>
         </div>
 
         <div class="terminal-line flex items-center my-2 gap-2 opacity-0" id="line-3">
-          <span class="text-green-400 font-bold">$</span>
-          <span class="text-white" id="cmd-3"></span>
+          <span class="text-green-600 dark:text-green-400 font-bold">$</span>
+          <span class="text-gray-800 dark:text-white" id="cmd-3"></span>
         </div>
         <div class="terminal-output my-2 mb-4 pl-0 opacity-0" id="output-3">
-          <div class="typing-text text-green-400 opacity-0" id="social-text">
+          <div class="typing-text text-green-600 dark:text-green-400 opacity-0" id="social-text">
             <div class="social-links flex flex-col gap-1">
-              <a href="https://discord.gg/faPNeuCQdF" target="_blank" rel="noreferrer" class="social-link text-green-400 no-underline flex items-center gap-2 py-1 transition-colors duration-300 hover:text-cyan-400 hover:underline">
+              <a href="https://discord.gg/faPNeuCQdF" target="_blank" rel="noreferrer" class="social-link text-green-600 dark:text-green-400 no-underline flex items-center gap-2 py-1 transition-colors duration-300 hover:text-cyan-600 dark:hover:text-cyan-400 hover:underline">
                 <svg class="w-6 h-6 md:w-8 md:h-8 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/>
                 </svg>
                 <span>Discord Server</span> <span class="text-yellow-400 ml-2 blink-text"><- join us!</span>
               </a>
-              <a href="https://www.youtube.com/@nw-union" target="_blank" rel="noreferrer" class="social-link text-green-400 no-underline flex items-center gap-2 py-1 transition-colors duration-300 hover:text-cyan-400 hover:underline">
+              <a href="https://www.youtube.com/@nw-union" target="_blank" rel="noreferrer" class="social-link text-green-600 dark:text-green-400 no-underline flex items-center gap-2 py-1 transition-colors duration-300 hover:text-cyan-600 dark:hover:text-cyan-400 hover:underline">
                 <svg class="w-6 h-6 md:w-8 md:h-8 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                 </svg>
                 <span>YouTube</span>
               </a>
-              <a href="https://github.com/nw-union" target="_blank" rel="noreferrer" class="social-link text-green-400 no-underline flex items-center gap-2 py-1 transition-colors duration-300 hover:text-cyan-400 hover:underline">
+              <a href="https://github.com/nw-union" target="_blank" rel="noreferrer" class="social-link text-green-600 dark:text-green-400 no-underline flex items-center gap-2 py-1 transition-colors duration-300 hover:text-cyan-600 dark:hover:text-cyan-400 hover:underline">
                 <svg class="w-6 h-6 md:w-8 md:h-8 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
                 </svg>
@@ -48,9 +50,9 @@ import Layout from "../layouts/Layout.astro";
         </div>
 
         <div class="terminal-line flex items-center my-2 gap-2 opacity-0" id="line-4">
-          <span class="text-green-400 font-bold">$</span>
-          <span class="text-white" id="cmd-4"></span>
-          <span class="cursor text-green-400 animate-pulse" id="cursor">_</span>
+          <span class="text-green-600 dark:text-green-400 font-bold">$</span>
+          <span class="text-gray-800 dark:text-white" id="cmd-4"></span>
+          <span class="cursor text-green-600 dark:text-green-400 animate-pulse" id="cursor">_</span>
         </div>
       </div>
     </div>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
+  darkMode: 'class',
   theme: {
     extend: {
       width: {


### PR DESCRIPTION
## 概要
トップページにライトモード/ダークモード切り替え機能を追加しました。

## 関連 Issue
特になし

## 変更内容
- 右上に太陽/月アイコンの切り替えボタンを配置
- Tailwind CSSのクラスベースダークモード（`darkMode: 'class'`）を設定
- ユーザーの選択をlocalStorageに保存し、次回訪問時も維持
- ターミナル風デザインを両モードで見やすく調整
  - ライトモード：明るい背景に緑系の文字
  - ダークモード：黒い背景に明るい緑の文字

## 確認事項
- [x] 動作確認済み
- [x] Biomeによるコードフォーマット実行済み
- [ ] テストの追加・更新（該当なし）
- [ ] ドキュメントの追加・更新（該当なし）

## その他
システムのダークモード設定も考慮し、初回訪問時は適切なモードが自動選択されます。

---

GitHub Copilot へ：日本語でコードレビューしてください。

🤖 Generated with [Claude Code](https://claude.ai/code)