### PR TITLE
feat: 404ページとMarkdownレイアウトにダークモード切り替え機能を追加

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -25,15 +25,15 @@ if (pathname.startsWith("/docs")) {
 ---
 
 {breadcrumbs.length > 0 && (
-  <nav class="mb-8 text-sm text-gray-400" aria-label="breadcrumb navigation">
+  <nav class="mb-8 text-sm text-gray-600 dark:text-gray-400" aria-label="breadcrumb navigation">
     {breadcrumbs.map((crumb, index) => (
       <span>
         {crumb.url ? (
-          <a href={crumb.url} class="text-cyan-400 hover:text-cyan-300 hover:underline transition-colors">
+          <a href={crumb.url} class="text-cyan-600 dark:text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 hover:underline transition-colors">
             {crumb.title}
           </a>
         ) : (
-          <span class="text-gray-300">{crumb.title}</span>
+          <span class="text-gray-800 dark:text-gray-300">{crumb.title}</span>
         )}
         {index < breadcrumbs.length - 1 && <span class="mx-2">＞</span>}
       </span>

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -29,7 +29,7 @@ if (pathname.startsWith("/docs")) {
     {breadcrumbs.map((crumb, index) => (
       <span>
         {crumb.url ? (
-          <a href={crumb.url} class="text-cyan-600 dark:text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 hover:underline transition-colors">
+          <a href={crumb.url} class="text-blue-600 dark:text-cyan-400 hover:text-blue-700 dark:hover:text-cyan-300 hover:underline transition-colors">
             {crumb.title}
           </a>
         ) : (

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/markdown.css";
 import Breadcrumb from "../components/Breadcrumb.astro";
+import ThemeToggle from "../components/ThemeToggle.astro";
 
 const { frontmatter } = Astro.props;
 
@@ -54,7 +55,8 @@ const twitterCard = frontmatter.twitterCard || "summary";
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sawarabi+Gothic&family=VT323&display=swap" rel="stylesheet" />
   </head>
-  <body class="bg-black font-sg leading-relaxed text-base md:w-700 w-full mx-auto p-6 text-gray-300">
+  <body class="bg-white dark:bg-black font-sg leading-relaxed text-base md:w-700 w-full mx-auto p-6 text-gray-800 dark:text-gray-300 transition-colors duration-300">
+    <ThemeToggle />
     <Breadcrumb currentTitle={frontmatter.title} />
     <slot />
   </body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
-import ThemeToggle from "../components/ThemeToggle.astro";
 import Layout from "../layouts/Layout.astro";
+import ThemeToggle from "../components/ThemeToggle.astro";
 ---
 
 <Layout title="404 Not Found | NWU" description="Page Not Found">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,18 +1,20 @@
 ---
+import ThemeToggle from "../components/ThemeToggle.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="404 Not Found | NWU" description="Page Not Found">
-  <main class="bg-black min-h-screen flex flex-col justify-start items-center p-4 pt-14">
-    <div class="bg-black font-vt323 text-2xl md:text-4xl leading-relaxed md:leading-loose max-w-4xl w-full">
-      <div class="p-3 md:p-5 bg-black min-h-300 md:min-h-400">
+  <ThemeToggle />
+  <main class="bg-white dark:bg-black min-h-screen flex flex-col justify-start items-center p-4 pt-14 transition-colors duration-300">
+    <div class="bg-gray-100 dark:bg-black font-vt323 text-2xl md:text-4xl leading-relaxed md:leading-loose max-w-4xl w-full transition-colors duration-300">
+      <div class="p-3 md:p-5 bg-gray-100 dark:bg-black min-h-300 md:min-h-400 transition-colors duration-300">
         <div class="terminal-output my-2 pl-0">
           <div class="text-red-400">cd: /requested/path: No such file or directory</div>
         </div>
 
         <div class="terminal-output my-2 mb-4 pl-0">
-          <div class="text-gray-300">
-            <a href="/" class="text-cyan-400 hover:text-cyan-300 hover:underline">Return to home directory</a>
+          <div class="text-gray-800 dark:text-gray-300 transition-colors duration-300">
+            <a href="/" class="text-cyan-600 dark:text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 hover:underline transition-colors duration-300">Return to home directory</a>
           </div>
         </div>
 

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,69 +1,69 @@
 /* Headers */
 h1 {
-  @apply text-2xl mt-20 py-2 mb-14 font-medium text-center text-gray-300;
+  @apply text-2xl mt-20 py-2 mb-14 font-medium text-center text-gray-800 dark:text-gray-300;
 }
 h2 {
-  @apply text-xl mt-14 py-2 mb-4 font-medium border-b border-gray-600 text-gray-300;
+  @apply text-xl mt-14 py-2 mb-4 font-medium border-b border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-300;
 }
 h3,
 h4 {
-  @apply text-lg mt-12 mb-2 font-medium text-gray-300;
+  @apply text-lg mt-12 mb-2 font-medium text-gray-800 dark:text-gray-300;
 }
 
 /* Links */
 a {
-  @apply text-cyan-400;
+  @apply text-blue-600 dark:text-cyan-400;
 }
 a:hover {
-  @apply underline text-cyan-300;
+  @apply underline text-blue-700 dark:text-cyan-300;
 }
 
 /* Paragraph */
 p {
-  @apply mb-8 text-justify hyphens-auto text-gray-300;
+  @apply mb-8 text-justify hyphens-auto text-gray-700 dark:text-gray-300;
 }
 
 /* Lists */
 li {
-  @apply m-1 text-gray-300;
+  @apply m-1 text-gray-700 dark:text-gray-300;
 }
 ol {
-  @apply list-decimal mb-4 ml-8 text-gray-300;
+  @apply list-decimal mb-4 ml-8 text-gray-700 dark:text-gray-300;
 }
 ul {
-  @apply list-disc mb-4 ml-5 text-gray-300;
+  @apply list-disc mb-4 ml-5 text-gray-700 dark:text-gray-300;
 }
 
 /* Blockquotes */
 blockquote {
-  @apply p-2 mx-6 bg-gray-800 mb-4 border-l-4 border-green-400 italic text-gray-300;
+  @apply p-2 mx-6 bg-gray-100 dark:bg-gray-800 mb-4 border-l-4 border-blue-500 dark:border-green-400 italic text-gray-700 dark:text-gray-300;
 }
 blockquote > p {
-  @apply mb-0 text-gray-300;
+  @apply mb-0 text-gray-700 dark:text-gray-300;
 }
 
 /* Tables */
 td,
 th {
-  @apply px-2 py-1 border border-gray-600 text-gray-300;
+  @apply px-2 py-1 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300;
 }
 thead tr {
-  @apply bg-gray-800;
+  @apply bg-gray-100 dark:bg-gray-800;
 }
 tbody tr:nth-child(even) {
-  @apply bg-gray-800;
+  @apply bg-gray-50 dark:bg-gray-800;
 }
 table {
-  @apply mb-6 bg-gray-900;
+  @apply mb-6 bg-white dark:bg-gray-900;
 }
 
 /* Code */
 :not(pre) > code {
-  @apply bg-gray-800 px-1 py-0.5 rounded text-sm text-green-400;
+  @apply bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-sm text-red-600 dark:text-green-400;
 }
 pre {
-  @apply bg-gray-900 rounded overflow-x-auto mb-6 border border-gray-700;
+  @apply bg-gray-50 dark:bg-gray-900 rounded overflow-x-auto mb-6 border border-gray-200 dark:border-gray-700;
 }
 pre code {
-  @apply block text-sm p-4 text-green-400 bg-transparent;
+  @apply block text-sm p-4 text-gray-800 dark:text-green-400 bg-transparent;
 }


### PR DESCRIPTION
## 概要

トップページ以外にも、ダークモードとライトモードの切り替え機能を実装

## 変更内容

- 404ページ（`src/pages/404.astro`）にThemeToggleコンポーネントを追加
- Markdownレイアウト（`src/layouts/Markdown.astro`）にThemeToggleコンポーネントを追加
- ダークモード対応のTailwind CSSクラスを適用
- スムーズなトランジション効果を追加

## 関連 Issue

Closes #12

Generated with [Claude Code](https://claude.ai/code)