### PR TITLE
feat: デフォルトテーマをダークモードに変更

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -22,7 +22,7 @@
     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
       return 'dark';
     }
-    return 'light';
+    return 'dark';
   })();
 
   if (theme === 'light') {


### PR DESCRIPTION
## 概要
デフォルトテーマをライトモードからダークモードに変更しました。

## 変更内容
- `src/components/ThemeToggle.astro`のフォールバック値を「light」から「dark」に変更
- ユーザー設定やシステム設定がない場合にダークモードが適用される

## 関連Issue
Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)